### PR TITLE
Added argument max_tries to be passed with jdomain

### DIFF
--- a/src/ngx_http_upstream_jdomain_module.c
+++ b/src/ngx_http_upstream_jdomain_module.c
@@ -15,6 +15,7 @@
 #define NGX_JDOMAIN_ARG_STR_MAX_IPS "max_ips="
 #define NGX_JDOMAIN_ARG_STR_PORT "port="
 #define NGX_JDOMAIN_ARG_STR_STRICT "strict"
+#define NGX_JDOMAIN_ARG_STR_MAX_FAILS "max_fails="
 
 typedef struct
 {
@@ -551,6 +552,15 @@ ngx_http_upstream_jdomain(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 			continue;
 		}
 
+		arglen = ngx_strlen(NGX_JDOMAIN_ARG_STR_MAX_FAILS);
+		if (ngx_strncmp(value[i].data, NGX_JDOMAIN_ARG_STR_MAX_FAILS, arglen) == 0) {
+			num = ngx_atoi(value[i].data + arglen, value[i].len - arglen);
+			if (num < 1) {
+				goto invalid;
+			}
+			server->max_fails = num;
+			continue;
+		}
 		goto invalid;
 	}
 


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>
Add max_tries for the server instances

## Description
The plugin does not support set_max_tries by default.
This change will make sure that even if the resolution fails the server will be tried out the number of times mentioned under max_tries.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
